### PR TITLE
XF10-33: XF10 Bringup [Harvester]

### DIFF
--- a/source/HarvesterSsp/webpa_interface.c
+++ b/source/HarvesterSsp/webpa_interface.c
@@ -469,7 +469,7 @@ char * getDeviceMac()
 	char getList[256] = "Device.DPoE.Mac_address";
 	char* getList1[] = {"Device.DPoE.Mac_address"};
 #else
-#if defined (_HUB4_PRODUCT_REQ_) || defined(_SR300_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_)
+#if defined (_HUB4_PRODUCT_REQ_) || defined(_SR300_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_) || defined(_SCXF11BFL_PRODUCT_REQ_)
         char getList[256] = "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC";
         char* getList1[] = {"Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"};
 #else


### PR DESCRIPTION
Reason for change: Necessary changes in Harvester component for XF10 bringup.
Test Procedure: Build should work with flag _SCXF11BFL_PRODUCT_REQ_