### PR TITLE
RDKB-61774 :[harvester] Code development to remove _64BIT_ARCH_SUPPORT_ macro

### DIFF
--- a/source/HarvesterSsp/harvester_associated_devices_avropack.c
+++ b/source/HarvesterSsp/harvester_associated_devices_avropack.c
@@ -19,6 +19,7 @@
    
 #include <stdio.h>
 #include <assert.h>
+#include <inttypes.h>
 #include <avro.h>
 #include <arpa/inet.h>
 #include <semaphore.h>  /* Semaphore */
@@ -286,11 +287,6 @@ void harvester_report_associateddevices(struct associateddevicedata *head, char*
 
   avro_value_set_long(&optional, tstamp_av_main );
    /* Coverity Fix CID: 124833  PRINTF_ARGS*/ 
-#ifdef _64BIT_ARCH_SUPPORT_
-  CcspHarvesterConsoleTrace(("RDK_LOG_DEBUG, timestamp = %ld\n", tstamp_av_main ));
-#else
-  CcspHarvesterConsoleTrace(("RDK_LOG_DEBUG, timestamp = %lld\n", tstamp_av_main ));
-#endif
   CcspHarvesterConsoleTrace(("RDK_LOG_DEBUG, timestamp = ""%" PRId64 "\n", tstamp_av_main ));
 
   CcspHarvesterConsoleTrace(("RDK_LOG_DEBUG, timestamp\tType: %d\n", avro_value_get_type(&optional)));

--- a/source/HarvesterSsp/harvester_radio_traffic_avropack.c
+++ b/source/HarvesterSsp/harvester_radio_traffic_avropack.c
@@ -19,6 +19,7 @@
    
 #include <stdio.h>
 #include <assert.h>
+#include <inttypes.h>
 #include <avro.h>
 #include <arpa/inet.h>
 #include <semaphore.h>  /* Semaphore */
@@ -328,11 +329,7 @@ void harvester_report_radiotraffic(struct radiotrafficdata *ptr)
 
   avro_value_set_long(&optional, tstamp_av_main );
    /* Coverity Fix CID: 125074  PRINTF_ARGS */
-#ifdef _64BIT_ARCH_SUPPORT_
-  CcspHarvesterConsoleTrace(("RDK_LOG_DEBUG, timestamp = %ld\n", tstamp_av_main ));
-#else
-  CcspHarvesterConsoleTrace(("RDK_LOG_DEBUG, timestamp = %lld\n", tstamp_av_main ));
-#endif
+  CcspHarvesterConsoleTrace(("RDK_LOG_DEBUG, timestamp =%" PRId64 "\n", tstamp_av_main ));
   CcspHarvesterConsoleTrace(("RDK_LOG_DEBUG, timestamp\tType: %d\n", avro_value_get_type(&optional)));
   if ( CHK_AVRO_ERR ) CcspHarvesterConsoleTrace(("RDK_LOG_DEBUG, %s\n", avro_strerror()));
 
@@ -548,11 +545,7 @@ void harvester_report_radiotraffic(struct radiotrafficdata *ptr)
       tstamp_av = tstamp_av/1000;
       avro_value_set_long(&optional, tstamp_av);
        /* Coverity Fix CID: 124885  PRINTF_ARGS*/
-#ifdef _64BIT_ARCH_SUPPORT_
-      CcspHarvesterConsoleTrace(("RDK_LOG_DEBUG, timestamp = %ld\n", tstamp_av));
-#else
-      CcspHarvesterConsoleTrace(("RDK_LOG_DEBUG, timestamp = %lld\n", tstamp_av));
-#endif
+      CcspHarvesterConsoleTrace(("RDK_LOG_DEBUG, timestamp = %" PRId64  "\n", tstamp_av));
       CcspHarvesterConsoleTrace(("RDK_LOG_DEBUG, timestamp\tType: %d\n", avro_value_get_type(&optional)));
       if ( CHK_AVRO_ERR ) CcspHarvesterConsoleTrace(("RDK_LOG_DEBUG, %s\n", avro_strerror()));
 


### PR DESCRIPTION
Reason for change: remove _64BIT_ARCH_SUPPORT_
macro from harvester module
Test Procedure: No build warning or errors.
basic sanity
Priority: P1
Risks: Low

Signed-off-by: mkorav871 <madhukrishnasmenon@comcast.com>