### PR TITLE
Fix CPU spike issue in Harvester

### DIFF
--- a/source/HarvesterSsp/harvester_associated_devices.c
+++ b/source/HarvesterSsp/harvester_associated_devices.c
@@ -878,6 +878,8 @@ void* StartAssociatedDeviceHarvesting( void *arg )
         else
         {
             CcspHarvesterTrace(("RDK_LOG_DEBUG, wifi_getSSIDNumberOfEntries Error [%d] or No SSID [%ld] \n", ret, output));
+            CcspHarvesterTrace(("RDK_LOG_ERROR, Harvester %s : Sleeping for 5 seconds before retrying\n", __FUNCTION__));
+            sleep(5); // Sleep for 5sec's time before retrying in case of error or no SSID, to avoid CPU load/busy looping.            
         }
 
         CcspHarvesterConsoleTrace(("RDK_LOG_DEBUG,GetIDWPollingPeriod[%ld]\n", GetIDWPollingPeriod()));


### PR DESCRIPTION
RDKB-65031 : [8.6s1][VXB10][Pi30]Increase in CPU due to Harvester process
Reason for change: Addressed high CPU usage issue observed in the Harvester service

Test Procedure:
Stop the onewifi service.
Set InterfaceDevicesWifi.PollingPeriod to 30 seconds.
Verify the Harvester logs:
Error logs should not flood continuously.
Error logs should appear only once every 5 seconds.
Verify that Harvester CPU usage does not increase abnormally.

Risks: Medium
Signed-off-by: LakshmiRangaiah_Narapuram@comcast.com