### PR TITLE
RDKB-65709: Integrate baseline changes for XER2 in Harvester

### DIFF
--- a/source/HarvesterSsp/webpa_interface.c
+++ b/source/HarvesterSsp/webpa_interface.c
@@ -469,10 +469,7 @@ char * getDeviceMac()
 	char getList[256] = "Device.DPoE.Mac_address";
 	char* getList1[] = {"Device.DPoE.Mac_address"};
 #else
-#if defined (_HUB4_PRODUCT_REQ_) || defined(_SR300_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_) || defined(_SCXF11BFL_PRODUCT_REQ_)
-        char getList[256] = "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC";
-        char* getList1[] = {"Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"};
-#elif defined(PON_GATEWAY)  /* PON/Fiber based gateways needs to be use Device.DeviceInfo.X_COMCAST-COM_WAN_MAC */
+#if defined (_HUB4_PRODUCT_REQ_) || defined(_SR300_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_) || defined(_SCXF11BFL_PRODUCT_REQ_) || defined(_XER2_PRODUCT_REQ_)
         char getList[256] = "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC";
         char* getList1[] = {"Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"};
 #else

--- a/source/HarvesterSsp/webpa_interface.c
+++ b/source/HarvesterSsp/webpa_interface.c
@@ -472,6 +472,9 @@ char * getDeviceMac()
 #if defined (_HUB4_PRODUCT_REQ_) || defined(_SR300_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_) || defined(_SCXF11BFL_PRODUCT_REQ_)
         char getList[256] = "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC";
         char* getList1[] = {"Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"};
+#elif defined(PON_GATEWAY)  /* PON/Fiber based gateways needs to be use Device.DeviceInfo.X_COMCAST-COM_WAN_MAC */
+        char getList[256] = "Device.DeviceInfo.X_COMCAST-COM_WAN_MAC";
+        char* getList1[] = {"Device.DeviceInfo.X_COMCAST-COM_WAN_MAC"};
 #else
         char getList[256] = "Device.X_CISCO_COM_CableModem.MACAddress";
         char* getList1[] = {"Device.X_CISCO_COM_CableModem.MACAddress"};


### PR DESCRIPTION
Reason for change: Incorporate baseline changes for XER2 in Harvester component.

This change includes:
- Use Device.DeviceInfo.X_COMCAST-COM_WAN_MAC DML to get WANMAC

Test Procedure:
1. Build should be successful
2. harvester should be running

Priority:P2
Risks: Low
Signed-off-by: Vysakh A V <vysakh.venugopal@sky.uk>

BUILD Verification with the custom branch is ok:
Reference: https://gerrit.teamccp.com/#/c/961708/ 